### PR TITLE
Adds HTTP caching headers to responses in PackageResourceServer

### DIFF
--- a/LauncherOSX.xcodeproj/project.pbxproj
+++ b/LauncherOSX.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		552FC46616F39AB5000E73BA /* icon.icns in Resources */ = {isa = PBXBuildFile; fileRef = 552FC46516F39AB5000E73BA /* icon.icns */; };
+		5998CC401CD4E0CF00BDAF46 /* NSDate+RDDateAsString.m in Sources */ = {isa = PBXBuildFile; fileRef = 5998CC3F1CD4E0CF00BDAF46 /* NSDate+RDDateAsString.m */; };
+		5998CC451CD4E38400BDAF46 /* RDPackageResourceDataResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 5998CC441CD4E38400BDAF46 /* RDPackageResourceDataResponse.m */; };
 		83412B311AC98D660074111F /* readium-external-libs.js.bundles.js in CopyFiles */ = {isa = PBXBuildFile; fileRef = 83412B271AC98D530074111F /* readium-external-libs.js.bundles.js */; };
 		83412B341AC98D660074111F /* readium-shared-js.js.bundles.js in CopyFiles */ = {isa = PBXBuildFile; fileRef = 83412B2A1AC98D530074111F /* readium-shared-js.js.bundles.js */; };
 		83766D471A0E9C77008077E1 /* epubReadingSystem.js in CopyFiles */ = {isa = PBXBuildFile; fileRef = 83766D431A0E9C53008077E1 /* epubReadingSystem.js */; };
@@ -186,6 +188,10 @@
 /* Begin PBXFileReference section */
 		552FC46516F39AB5000E73BA /* icon.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = icon.icns; sourceTree = "<group>"; };
 		558E562716EF859800FCF273 /* ePub3.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ePub3.xcodeproj; path = "readium-sdk/Platform/Apple/ePub3.xcodeproj"; sourceTree = "<group>"; };
+		5998CC3E1CD4E0CF00BDAF46 /* NSDate+RDDateAsString.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDate+RDDateAsString.h"; sourceTree = "<group>"; };
+		5998CC3F1CD4E0CF00BDAF46 /* NSDate+RDDateAsString.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDate+RDDateAsString.m"; sourceTree = "<group>"; };
+		5998CC431CD4E38400BDAF46 /* RDPackageResourceDataResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RDPackageResourceDataResponse.h; sourceTree = "<group>"; };
+		5998CC441CD4E38400BDAF46 /* RDPackageResourceDataResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RDPackageResourceDataResponse.m; sourceTree = "<group>"; };
 		83412B271AC98D530074111F /* readium-external-libs.js.bundles.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = "readium-external-libs.js.bundles.js"; path = "readium-shared-js/build-output/_multiple-bundles/readium-external-libs.js.bundles.js"; sourceTree = "<group>"; };
 		83412B2A1AC98D530074111F /* readium-shared-js.js.bundles.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = "readium-shared-js.js.bundles.js"; path = "readium-shared-js/build-output/_multiple-bundles/readium-shared-js.js.bundles.js"; sourceTree = "<group>"; };
 		83766D431A0E9C53008077E1 /* epubReadingSystem.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = epubReadingSystem.js; path = LauncherOSX/ReaderScripts/epubReadingSystem.js; sourceTree = "<group>"; };
@@ -513,6 +519,10 @@
 		A250D23B175D03DBBBCD0E09 /* AssetData */ = {
 			isa = PBXGroup;
 			children = (
+				5998CC431CD4E38400BDAF46 /* RDPackageResourceDataResponse.h */,
+				5998CC441CD4E38400BDAF46 /* RDPackageResourceDataResponse.m */,
+				5998CC3E1CD4E0CF00BDAF46 /* NSDate+RDDateAsString.h */,
+				5998CC3F1CD4E0CF00BDAF46 /* NSDate+RDDateAsString.m */,
 				A250D4C9D6CACD35912BAF87 /* PackageResourceServer.h */,
 				A250DD60BF5DB25EC732A173 /* PackageResourceServer.mm */,
 				A250DB0DD4746DF18C3F2E02 /* RDPackageResource.h */,
@@ -902,6 +912,7 @@
 				A250DBBAE4D1A71F94E7290A /* DispatchQueueLogFormatter.m in Sources */,
 				83F7B67B1B2AD72800DFF6B6 /* readium-cfi-js.js.map in Sources */,
 				A250DA45DF0ACCA38ED50DB0 /* DDASLLogger.m in Sources */,
+				5998CC451CD4E38400BDAF46 /* RDPackageResourceDataResponse.m in Sources */,
 				83F7B6811B2AD72800DFF6B6 /* readium-shared-js.js.map in Sources */,
 				A250D1E2A3BFDE4B6603C02F /* DDTTYLogger.m in Sources */,
 				A250DBE5055F6CDD04051D05 /* DDFileLogger.m in Sources */,
@@ -909,6 +920,7 @@
 				A250D68A29723F304FF5A543 /* GCDAsyncSocket.m in Sources */,
 				AD8C844CC4BC879DBC059A12 /* LOXBookmark.mm in Sources */,
 				AD8C876EC2AB74129A5C39B4 /* LOXBook.mm in Sources */,
+				5998CC401CD4E0CF00BDAF46 /* NSDate+RDDateAsString.m in Sources */,
 				AD8C8764B6F6057D08B07744 /* LOXUserData.mm in Sources */,
 				AD8C808F484D84E55FCCDF93 /* LOXTocEntry.m in Sources */,
 				AD8C8EFDC93A1A1F1B7B9509 /* LOXToc.mm in Sources */,

--- a/LauncherOSX/NSDate+RDDateAsString.h
+++ b/LauncherOSX/NSDate+RDDateAsString.h
@@ -1,0 +1,15 @@
+//
+//  NSDate+RDDateAsString.h
+//  Art Book Magazine
+//
+//  Created by Olivier Körner on 12/04/2016.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSDate (RDDateAsString)
+
+- (NSString *)dateAsString;
+
+@end

--- a/LauncherOSX/NSDate+RDDateAsString.m
+++ b/LauncherOSX/NSDate+RDDateAsString.m
@@ -1,0 +1,51 @@
+//
+//  NSDate+RDDateAsString.m
+//  Art Book Magazine
+//
+//  Created by Olivier Körner on 12/04/2016.
+//
+//
+
+#import "NSDate+RDDateAsString.h"
+
+@implementation NSDate (RDDateAsString)
+
+/**
+ * Gets the current date and time, formatted properly (according to RFC) for insertion into an HTTP header.
+ **/
+- (NSString *)dateAsString
+{
+    // From Apple's Documentation (Data Formatting Guide -> Date Formatters -> Cache Formatters for Efficiency):
+    //
+    // "Creating a date formatter is not a cheap operation. If you are likely to use a formatter frequently,
+    // it is typically more efficient to cache a single instance than to create and dispose of multiple instances.
+    // One approach is to use a static variable."
+    //
+    // This was discovered to be true in massive form via issue #46:
+    //
+    // "Was doing some performance benchmarking using instruments and httperf. Using this single optimization
+    // I got a 26% speed improvement - from 1000req/sec to 3800req/sec. Not insignificant.
+    // The culprit? Why, NSDateFormatter, of course!"
+    //
+    // Thus, we are using a static NSDateFormatter here.
+    
+    static NSDateFormatter *df;
+    
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        
+        // Example: Sun, 06 Nov 1994 08:49:37 GMT
+        
+        df = [[NSDateFormatter alloc] init];
+        [df setFormatterBehavior:NSDateFormatterBehavior10_4];
+        [df setTimeZone:[NSTimeZone timeZoneWithAbbreviation:@"GMT"]];
+        [df setDateFormat:@"EEE, dd MMM y HH:mm:ss 'GMT'"];
+        [df setLocale:[[NSLocale alloc] initWithLocaleIdentifier:@"en_US"]];
+        
+        // For some reason, using zzz in the format string produces GMT+00:00
+    });
+    
+    return [df stringFromDate:self];
+}
+
+@end

--- a/LauncherOSX/RDPackageResourceDataResponse.h
+++ b/LauncherOSX/RDPackageResourceDataResponse.h
@@ -1,0 +1,34 @@
+//
+//  RDPackageResourceDataResponse.h
+//  SDKLauncher-iOS
+//
+//  Created by Oliver Eikemeier on 04.04.14.
+//  Copyright (c) 2014 Readium Foundation and/or its licensees. All rights reserved.
+//  
+//  Redistribution and use in source and binary forms, with or without modification, 
+//  are permitted provided that the following conditions are met:
+//  1. Redistributions of source code must retain the above copyright notice, this 
+//  list of conditions and the following disclaimer.
+//  2. Redistributions in binary form must reproduce the above copyright notice, 
+//  this list of conditions and the following disclaimer in the documentation and/or 
+//  other materials provided with the distribution.
+//  3. Neither the name of the organization nor the names of its contributors may be 
+//  used to endorse or promote products derived from this software without specific 
+//  prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+//  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+//  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+//  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+//  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED 
+//  OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#import "HTTPDataResponse.h"
+
+@interface RDPackageResourceDataResponse : HTTPDataResponse
+
+@end

--- a/LauncherOSX/RDPackageResourceDataResponse.m
+++ b/LauncherOSX/RDPackageResourceDataResponse.m
@@ -1,0 +1,54 @@
+//
+//  RDPackageResourceDataResponse.m
+//  SDKLauncher-iOS
+//
+//  Created by Oliver Eikemeier on 04.04.14.
+//  Copyright (c) 2014 Readium Foundation and/or its licensees. All rights reserved.
+//  
+//  Redistribution and use in source and binary forms, with or without modification, 
+//  are permitted provided that the following conditions are met:
+//  1. Redistributions of source code must retain the above copyright notice, this 
+//  list of conditions and the following disclaimer.
+//  2. Redistributions in binary form must reproduce the above copyright notice, 
+//  this list of conditions and the following disclaimer in the documentation and/or 
+//  other materials provided with the distribution.
+//  3. Neither the name of the organization nor the names of its contributors may be 
+//  used to endorse or promote products derived from this software without specific 
+//  prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+//  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+//  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+//  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+//  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED 
+//  OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#import "RDPackageResourceDataResponse.h"
+#import "NSDate+RDDateAsString.h"
+
+NSString * const kDataCacheControlHTTPHeader = @"no-transform,public,max-age=3000,s-maxage=9000";
+
+@implementation RDPackageResourceDataResponse
+
+- (NSDictionary *)httpHeaders {
+    NSDate *now = [NSDate date];
+    NSString *nowStr = [now dateAsString];
+    NSString *expStr = [[now dateByAddingTimeInterval:60*60*24*10] dateAsString];
+	if (contentType) {
+		return @{@"Content-Type": contentType,
+                 @"Cache-Control": kDataCacheControlHTTPHeader,
+                 @"Last-Modified": nowStr,
+                 @"Expires": expStr};
+	}
+	else {
+		return @{@"Cache-Control": kDataCacheControlHTTPHeader,
+                 @"Last-Modified": nowStr,
+                 @"Expires": expStr};
+	}
+}
+ 
+@end


### PR DESCRIPTION
Fixes #47.
Adds HTTP caching headers to the responses in PackageResourceServer.
As RDServices are not yet ported to OSX, I had to copy and port some files from RDServices in iOS.
